### PR TITLE
Delete white spaces

### DIFF
--- a/zimbra_monitoring.sh
+++ b/zimbra_monitoring.sh
@@ -22,7 +22,7 @@ case "$1" in
 	  exit 1
 	fi
 
-        state="$(/usr/bin/tail -n 1000 $zimbra_log_file | grep STATUS | grep $1 | tail -1 | cut -d ':' -f 11)"
+        state="$(/usr/bin/tail -n 1000 $zimbra_log_file | grep STATUS | grep $1 | tail -1 | cut -d ':' -f 11 | tr -d '[:space:]')"
 
 	if [ "$state" != "Running" ]; then
 	  echo 0


### PR DESCRIPTION
Else, zabbix show service Down, while service realy is Up